### PR TITLE
Update parseMultiAllelic.py

### DIFF
--- a/exec/parseMultiAllelic.py
+++ b/exec/parseMultiAllelic.py
@@ -6,82 +6,107 @@
 # Unlike previous versions this script makes no assumptions about ploidy
 # Validate to work fine on test data
 
-import sys, re, gzip
-handle=sys.argv[1]
-if handle=="-":
-	handle=sys.stdin
-elif handle[-3:]==".gz":
-	handle=gzip.open(handle,'r')
-else:
-	handle=open(handle,'r')
+import gzip
+import re
+import sys
 
 
 def parse_site(line):
-	# Function for parsing vcf records [site info only]
-	i=re.split("\t",line)
-	alleles=re.split(",",i[4])
-	if len(alleles)==1:
-		return([line])
-	else:
-		lines=[]
-		for i2 in range(len(alleles)):
-			a=str(i2+1)
-			out="\t".join(i[:4]+[alleles[i2]]+i[5:])
-			lines.append(out)
-		return(lines)
+    """
+    Function for parsing vcf records [site info only]
+    """
+
+    i = re.split("\t", line)
+    alleles = re.split(",", i[4])
+    if len(alleles) == 1:
+        return [line]
+    return ["\t".join(i[:4] + [alleles[i2]] + i[5:]) for i2 in range(len(alleles))]
+
+
+def get_alleles(line):
+    """
+    extract the allels (5th column of vcf file)
+    returns a list of allels
+    """
+
+    # cut off is set to not split complete (very long) line
+    cutoff = 250
+    fields = line[:250].split("\t")
+    # if not enough field are found, try to split a larger string
+    while len(fields) <= 6:
+        cutoff = cutoff + 250
+        fields = line[:cutoff].split("\t")
+
+    return fields[4].split(",")
 
 
 def parse(line):
-	# Function for parsing vcf records
-	line=re.sub("\./\.:[^\t\n]*","./.",line)
-	i=re.split("\t",line)
-	alleles=re.split(",",i[4])
-	if len(alleles)==1:
-		return([line])
-	else:
-		lines=[]
-		gti=re.split(":",i[8]).index("GT")	# Position of GT in format field
-		i[-1]=i[-1].strip()
-		for i2 in range(len(alleles)):
-			a=str(i2+1)
-			out="\t".join(i[:4]+[alleles[i2]]+i[5:9])
-			for i3 in i[9:]:				
-				i3=re.split(":",i3)
-				if "." in re.split("/|\|",i3[gti]):	# Ignore sites with missing genotype data
-					None
-				else:
-					i3[gti]="/".join(["1" if allele==a else "0" for allele in re.split("/|\|",i3[gti])])
-				out+="\t"+":".join(i3)
-			lines.append(out+"\n")
-		return(lines)
+    """
+    Function for parsing vcf records
+    """
+    line = re.sub(r"\./\.:[^\t\n]*", r"./.", line)
+    alleles = get_alleles(line)
+    if len(alleles) == 1:
+        return [line]
+    i = line.split("\t")
+
+    gti = i[8].split(":").index("GT")  # Position of GT in format field
+    i[-1] = i[-1].strip()
+
+    # genereed the  fixed fields
+    outlist = [
+        ["\t".join(i[:4] + [alleles[i2]] + i[5:9])] for i2 in range(len(alleles))
+    ]
+
+    for genotype_field in i[9:]:
+        genotype_field = genotype_field.split(":")
+        genotypes = re.split(r"/|\|", genotype_field[gti])
+        for i2 in range(len(alleles)):
+            if "." in genotypes:  # Ignore sites with missing genotype data
+                None
+            else:
+                a = str(i2 + 1)
+                genotype_field[gti] = "/".join(
+                    ["1" if allele == a else "0" for allele in genotypes]
+                )
+            outlist[i2].append(":".join(genotype_field))
+
+    return [r + "\n" for r in ["\t".join(out) for out in outlist]]
 
 
+def main():
+    handle = sys.argv[1]
+    if handle == "-":
+        handle = sys.stdin
+    elif handle.endswith(".gz"):
+        handle = gzip.open(handle, "rt", encoding="utf8")
+    else:
+        handle = open(handle, "rt")
 
-# Load file
-line=handle.readline()
+    # Load file
+    line = handle.readline()
 
-# write header
-while line[0]=="#":
-	sys.stdout.write(line)
-	line=handle.readline()
+    # write header
+    while line[0] == "#":
+        sys.stdout.write(line)
+        line = handle.readline()
 
-# If site only vcf
-if len(re.split("\t",line))==8:
-	while True:
-		if line=="":
-			break
-		for i in parse_site(line):
-			sys.stdout.write(i)
-			None
-		line=handle.readline()
+    # If site only vcf
+    # print(line)
+    if len(re.split("\t", line)) == 8:
+        while line != "":
+            for i in parse_site(line):
+                sys.stdout.write(i)
+                None
+            line = handle.readline()
 
-# If genotypes present
-else:
-	while True:
-		if line=="":
-			break
-		for i in parse(line):
-			sys.stdout.write(i)
-			None
-		line=handle.readline()
+    else:
+        while line != "":
+            for i in parse(line):
+                sys.stdout.write(i)
+                None
+            line = handle.readline()
 
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
While I was trying to fix the gzip input of the `parseMultiAllelic.py`, things got out of control and except for fixing the gzip input, the script run 2 times faster while maintaining identical output.

- fixed gzip'ed files as input
- detection of multiple variants does not split the complete line. This speeds up variant lines.
- replaced re.spit() by computational cheaper split() where possible
- "unrolled" loop to prevent run re.split multiple times into the same data
- removed unused variables (a=str(i2+1))
- generated a main function
- removed unneeded while loops
- transformed loops into comparisons
- some code styling