### PR TITLE
fix: Changed URL

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -25,5 +25,5 @@ navbar:
     href: articles/faq.html
  right:
    - icon: fa-github
-     href: https://github.com/kkenna/rvat
+     href: https://github.com/KennaLab/rvat
      


### PR DESCRIPTION
It now points to current repo instead of the old one