### PR TITLE
minor fixes + update units tests for duckdb implementation

### DIFF
--- a/R/aggDb.R
+++ b/R/aggDb.R
@@ -14,7 +14,7 @@ aggdb <- function(path) {
   }
   tryCatch(
     {
-      con <- DBI::dbConnect(duckdb::duckdb(), path)
+      con <- DBI::dbConnect(DBI::dbDriver("SQLite"), path)
     },
     error = function(e) {
       stop(sprintf("Invalid aggdb path '%s'", path), call. = FALSE)
@@ -146,7 +146,7 @@ setMethod("getUnit", signature = "aggdb", definition = function(object, unit) {
   # connect to db
   tryCatch(
     {
-      aggdb <- DBI::dbConnect(duckdb::duckdb(), output)
+      aggdb <- DBI::dbConnect(RSQLite::SQLite(), output)
     },
     error = function(e) {
       stop(sprintf("Invalid aggdb path '%s'", output), call. = FALSE)

--- a/R/allClasses.R
+++ b/R/allClasses.R
@@ -707,7 +707,7 @@ NULL
 #' @rdname aggdb
 #' @usage NULL
 #' @export
-setClass("aggdb", contains = "duckdb_connection")
+setClass("aggdb", contains = "SQLiteConnection")
 
 
 #' Class to facilitate merging aggdbs

--- a/R/gdb-anno-cohort.R
+++ b/R/gdb-anno-cohort.R
@@ -54,10 +54,14 @@ setMethod(
 
     # build where statement
     if (!is.null(VAR_id)) {
-      VAR_id <- sprintf(
-        "VAR_id in (%s)",
-        paste(as.integer(VAR_id), collapse = ",")
-      )
+      if (length(VAR_id) > 0L) {
+        VAR_id <- sprintf(
+          "VAR_id in (%s)",
+          paste(as.integer(VAR_id), collapse = ",")
+        )
+      } else {
+        VAR_id <- "1=0"
+      }
       if (length(where) > 0L) {
         where <- sprintf("(%s) AND (%s)", VAR_id, where)
       } else {
@@ -221,12 +225,14 @@ setMethod(
     if (verbose) {
       message(sprintf("Loading table '%s' from '%s'", name, value))
     }
-    DBI::dbWriteTable(
-      con = gdb,
-      name = name,
-      value = value,
-      sep = sep, ## TODO: duckdb does not support sep? check if this gives errors
-      overwrite = TRUE
+    DBI::dbExecute(
+      gdb,
+      sprintf(
+        "CREATE TABLE %s AS SELECT * FROM read_csv_auto('%s', delim='%s')",
+        name,
+        value,
+        sep
+      )
     )
     source_info <- value
   } else {
@@ -614,8 +620,8 @@ setMethod(
     if (meta_cohort_exists) {
       DBI::dbExecute(
         object,
-        "DELETE FROM cohort WHERE name = :table_to_remove",
-        params = list(table_to_remove = name)
+        "DELETE FROM cohort WHERE name = ?",
+        params = list(name)
       )
     }
 

--- a/R/gdb-shared-helpers.R
+++ b/R/gdb-shared-helpers.R
@@ -102,6 +102,16 @@
       call. = FALSE
     )
   }
+
+  # add creation date
+  DBI::dbExecute(
+    gdb,
+    "INSERT INTO meta VALUES (?, ?)",
+    params = list(
+      "creationDate",
+      as.character(round(Sys.time(), units = "secs"))
+    )
+  )
 }
 
 

--- a/R/gdb-utils.R
+++ b/R/gdb-utils.R
@@ -68,8 +68,7 @@ concatGdb <- function(
     if (verbose) {
       message(sprintf("Merging '%s'", gdb_i))
     }
-    # DBI::dbExecute(gdb, sprintf("ATTACH '%s' AS src", gdb_i))
-    DBI::dbExecute(gdb, "attach ? as src", params = list(gdb_i))
+    DBI::dbExecute(gdb, sprintf("ATTACH '%s' AS src", gdb_i))
     DBI::dbExecute(gdb, "insert into var select * from src.var order by VAR_id")
     DBI::dbExecute(
       gdb,
@@ -111,8 +110,32 @@ concatGdb <- function(
         as.character(round(Sys.time(), units = "secs"))
       ))
     }
-    DBI::dbExecute(gdb, "update var set VAR_id=rowid") ##TODO: see how to do this with duckdb (where rowid is not supported?)
-    DBI::dbExecute(gdb, "update dosage set VAR_id=rowid")
+    DBI::dbExecute(
+      gdb,
+      "
+    WITH numbered AS (
+      SELECT rowid, ROW_NUMBER() OVER () AS new_id 
+      FROM var
+    )
+    UPDATE var 
+    SET VAR_id = numbered.new_id 
+    FROM numbered 
+    WHERE var.rowid = numbered.rowid
+    "
+    )
+    DBI::dbExecute(
+      gdb,
+      "
+    WITH numbered AS (
+      SELECT rowid, ROW_NUMBER() OVER () AS new_id 
+      FROM dosage
+    )
+    UPDATE dosage 
+    SET VAR_id = numbered.new_id 
+    FROM numbered 
+    WHERE dosage.rowid = numbered.rowid
+    "
+    )
   }
 
   # generate indexes
@@ -240,7 +263,7 @@ concatGdb <- function(
   if (verbose) {
     message("Creating SM, anno and cohort tables")
   }
-  DBI::dbExecute(gdb, "attach ? as src", params = list(gdb_list[1]))
+  DBI::dbExecute(gdb, sprintf("attach '%s' as src", gdb_list[1]))
   DBI::dbExecute(gdb, "create table SM as select * from src.SM")
   DBI::dbExecute(gdb, "detach src")
   DBI::dbExecute(gdb, "create table anno (name text,value text,date text)")

--- a/R/spatialClust.R
+++ b/R/spatialClust.R
@@ -59,7 +59,7 @@ setMethod(
 
     # add grouped concat
     query <- sprintf(
-      "select unit, group_concat(VAR_id) as VAR_id, group_concat(weight) as weight, '%s' as varSetName, group_concat(POS) as POS from (%s) x group by unit",
+      "select unit, group_concat(VAR_id order by VAR_id) as VAR_id, group_concat(weight order by VAR_id) as weight, '%s' as varSetName, group_concat(POS order by VAR_id) as POS from (%s) x group by unit order by unit",
       varSetName,
       query
     )

--- a/R/varSet.R
+++ b/R/varSet.R
@@ -854,7 +854,7 @@ setMethod(
 
   # add grouped concat
   query <- sprintf(
-    "select unit, group_concat(VAR_id) as VAR_id, group_concat(w) as w, '%s' as varSetName from (%s) x group by unit",
+    "select unit, group_concat(VAR_id order by VAR_id) as VAR_id, group_concat(w order by VAR_id) as w, '%s' as varSetName from (%s) x group by unit order by unit",
     varSetName,
     query
   )

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -4,3 +4,20 @@ library(rvatData)
 
 gdbpath <- rvat_example("rvatData.gdb")
 testgdb <- withr::local_tempfile()
+
+create_example_gdb <- function (gdbpath = NULL, filepath = NULL) 
+{
+    if (is.null(filepath)) {
+        filepath <- tempfile()
+    } else {
+        if (file.exists(filepath)) {
+            stop(sprintf("%s already exists. Please delete or use a different filepath.", 
+                filepath))
+        }
+    }
+    gdb <- test_path("data/rvatData.gdb")
+    if (!file.copy(gdb, filepath)) {
+        stop("Failed to copy example gdb")
+    }
+    gdb(filepath)
+}

--- a/tests/testthat/test-assocTest.R
+++ b/tests/testthat/test-assocTest.R
@@ -360,9 +360,10 @@ test_that("dominant/recessive model filtering works", {
 
 test_that("assocTest-gdb and assocTest-GT result in identical output", {
   params <- generate_param()
+  gdb <- create_example_gdb()
   warnings <- capture_warnings(
     run_test_gdb <- run_tests_gdb(
-      gdb(rvat_example("rvatData.gdb")),
+      gdb,
       params,
       VAR_id = rownames(GT),
       var_sv = rownames(GT)[1:25]

--- a/tests/testthat/test-cli.R
+++ b/tests/testthat/test-cli.R
@@ -3,6 +3,9 @@
 # - directly checks if arguments are passed correctly, rather than indirectly by checking outputs etc.
 # - tests will directly fail if parameters or defaults ihave not been properly updated in CLI
 
+gdb <- create_example_gdb()
+gdb_path <- getGdbPath(gdb)
+
 # buildGdb
 test_that("--buildGdb works", {
   # generate mocked function/method that returns the environment
@@ -189,7 +192,7 @@ test_that("--subsetGdb works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--subsetGdb",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--output=example_subset.gdb"
       )
     },
@@ -205,7 +208,7 @@ test_that("--subsetGdb works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     output = "example_subset.gdb"
   )
   expected_args <- c(
@@ -225,7 +228,7 @@ test_that("--subsetGdb works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--subsetGdb",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--output=example.gdb",
         "--intersection=varInfo",
         "--where='ModerateImpact = 1'",
@@ -248,7 +251,7 @@ test_that("--subsetGdb works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     output = "example.gdb",
     intersection = "varInfo",
     where = "'ModerateImpact = 1'",
@@ -289,7 +292,7 @@ test_that("--uploadAnno works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--uploadAnno",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--name=data",
         "--value=data.txt"
       )
@@ -306,7 +309,7 @@ test_that("--uploadAnno works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     name = "data",
     value = "data.txt"
   )
@@ -325,7 +328,7 @@ test_that("--uploadAnno works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--uploadAnno",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--name=data",
         "--value=data.txt",
         "--sep='|'",
@@ -350,7 +353,7 @@ test_that("--uploadAnno works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     name = "data",
     value = "data.txt",
     sep = "'|'",
@@ -393,7 +396,7 @@ test_that("--uploadCohort works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--uploadCohort",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--name=data",
         "--value=data.txt"
       )
@@ -410,7 +413,7 @@ test_that("--uploadCohort works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     name = "data",
     value = "data.txt"
   )
@@ -431,7 +434,7 @@ test_that("--uploadCohort works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--uploadCohort",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--name=data",
         "--value=data.txt",
         "--sep='|'",
@@ -451,7 +454,7 @@ test_that("--uploadCohort works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     name = "data",
     value = "data.txt",
     sep = "'|'",
@@ -492,7 +495,7 @@ test_that("--listAnno works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--listAnno",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb"))
+        sprintf("--gdb=%s", gdb_path)
       )
     },
     .package = "base"
@@ -507,7 +510,7 @@ test_that("--listAnno works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb"))
+    object = gdb
   )
   expected_args <- c(
     expected_args,
@@ -537,7 +540,7 @@ test_that("--listCohort works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--listCohort",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb"))
+        sprintf("--gdb=%s", gdb_path)
       )
     },
     .package = "base"
@@ -552,7 +555,7 @@ test_that("--listCohort works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb"))
+    object = gdb
   )
   expected_args <- c(
     expected_args,
@@ -581,7 +584,7 @@ test_that("--mapVariants works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--mapVariants",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb"))
+        sprintf("--gdb=%s", gdb_path)
       )
     },
     .package = "base"
@@ -596,7 +599,7 @@ test_that("--mapVariants works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb"))
+    object = gdb
   )
   expected_args <- c(
     expected_args,
@@ -615,7 +618,7 @@ test_that("--mapVariants works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--mapVariants",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--ranges=ranges.txt",
         "--gff=ensembl.gtf",
         "--bed=bedfile.bed",
@@ -641,7 +644,7 @@ test_that("--mapVariants works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     ranges = "ranges.txt",
     gff = "ensembl.gtf",
     bed = "bedfile.bed",
@@ -686,7 +689,7 @@ test_that("--buildVarSet works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--buildVarSet",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--varSetName=LOF",
         "--unitTable=gene",
         "--unitName=gene_id",
@@ -705,7 +708,7 @@ test_that("--buildVarSet works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     varSetName = "LOF",
     unitTable = "gene",
     unitName = "gene_id",
@@ -728,7 +731,7 @@ test_that("--buildVarSet works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--buildVarSet",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--varSetName=LOF",
         "--unitTable=gene",
         "--unitName=gene_id",
@@ -752,7 +755,7 @@ test_that("--buildVarSet works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     varSetName = "LOF",
     unitTable = "gene",
     unitName = "gene_id",
@@ -795,7 +798,7 @@ test_that("--spatialClust works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--spatialClust",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--output=varsetfile.txt.gz",
         "--varSetName=LOF",
         "--unitTable=gene",
@@ -816,7 +819,7 @@ test_that("--spatialClust works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     varSetName = "LOF",
     unitTable = "gene",
     unitName = "gene_id",
@@ -843,7 +846,7 @@ test_that("--spatialClust works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--spatialClust",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--varSetName=LOF",
         "--unitTable=gene",
         "--unitName=gene_id",
@@ -868,7 +871,7 @@ test_that("--spatialClust works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     varSetName = "LOF",
     unitTable = "gene",
     unitName = "gene_id",
@@ -915,7 +918,7 @@ test_that("--summariseGeno works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--summariseGeno",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--output=sumgeno.txt.gz"
       )
     },
@@ -931,7 +934,7 @@ test_that("--summariseGeno works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     output = "sumgeno.txt.gz"
   )
   expected_args <- c(
@@ -957,7 +960,7 @@ test_that("--summariseGeno works", {
   ## save varsetfile
   varsetfile <- withr::local_tempfile()
   buildVarSet(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     varSetName = "Moderate",
     unitTable = "varInfo",
     unitName = "gene_name",
@@ -974,7 +977,7 @@ test_that("--summariseGeno works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--summariseGeno",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--output=sumgeno.txt.gz",
         "--cohort=pheno",
         sprintf("--varSet=%s", varsetfile),
@@ -1013,7 +1016,7 @@ test_that("--summariseGeno works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     cohort = "pheno",
     VAR_id = as.character(1:10),
     pheno = "pheno",
@@ -1078,7 +1081,7 @@ test_that("--aggregate works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--aggregate",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         sprintf("--VAR_id=%s", varids),
         "--output=aggregate.txt.gz"
       )
@@ -1095,7 +1098,7 @@ test_that("--aggregate works", {
 
   # check against expected args
   expected_args <- list(
-    x = gdb(rvatData::rvat_example("rvatData.gdb")),
+    x = gdb,
     VAR_id = as.character(1:10),
     output = "aggregate.txt.gz"
   )
@@ -1119,7 +1122,7 @@ test_that("--aggregate works", {
   ## save varsetfile
   varsetfile <- withr::local_tempfile()
   buildVarSet(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     varSetName = "Moderate",
     unitTable = "varInfo",
     unitName = "gene_name",
@@ -1136,7 +1139,7 @@ test_that("--aggregate works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--aggregate",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--cohort=pheno",
         sprintf("--varSet=%s", varsetfile),
         sprintf("--VAR_id=%s", varids),
@@ -1177,7 +1180,7 @@ test_that("--aggregate works", {
 
   # check against expected args
   expected_args <- list(
-    x = gdb(rvatData::rvat_example("rvatData.gdb")),
+    x = gdb,
     cohort = "pheno",
     VAR_id = as.character(1:10),
     pheno = "pheno",
@@ -1236,7 +1239,7 @@ test_that("--mergeAggDbs works", {
   # test defaults
   aggdb1 <- withr::local_tempfile()
   aggdb2 <- withr::local_tempfile()
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- gdb
   agg1 <- aggregate(
     gdb,
     VAR_id = 1:10,
@@ -1345,7 +1348,7 @@ test_that("--collapseAggDbs works", {
   # test defaults
   aggdb1 <- withr::local_tempfile()
   aggdb2 <- withr::local_tempfile()
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- gdb
   agg1 <- aggregate(
     gdb,
     VAR_id = 1:10,
@@ -1461,7 +1464,7 @@ test_that("--assocTest works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--assocTest",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--pheno=pheno",
         "--test=firth",
         "--output=assocTest.txt.gz"
@@ -1479,7 +1482,7 @@ test_that("--assocTest works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     pheno = "pheno",
     test = "firth",
     output = "assocTest.txt.gz"
@@ -1504,7 +1507,7 @@ test_that("--assocTest works", {
   ## save varsetfile
   varsetfile <- withr::local_tempfile()
   null <- buildVarSet(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     varSetName = "Moderate",
     unitTable = "varInfo",
     unitName = "gene_name",
@@ -1529,7 +1532,7 @@ test_that("--assocTest works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--assocTest",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--pheno=pheno,sex",
         "--test=firth,glm,scoreSPA",
         "--cohort=pheno",
@@ -1581,7 +1584,7 @@ test_that("--assocTest works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     pheno = c("pheno", "sex"),
     test = c("firth", "glm", "scoreSPA"),
     cohort = "pheno",
@@ -1657,7 +1660,7 @@ test_that("--assocTest works", {
   genesetfile <- withr::local_tempfile()
 
   null <- buildVarSet(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     varSetName = "Moderate",
     unitTable = "varInfo",
     unitName = "gene_name",
@@ -1667,7 +1670,7 @@ test_that("--assocTest works", {
   )
 
   null <- aggregate(
-    x = gdb(rvatData::rvat_example("rvatData.gdb")),
+    x = gdb,
     varSet = getVarSet(varSetFile(varsetfile), unit = c("SOD1", "ABCA4")),
     output = aggdb,
     verbose = FALSE
@@ -1690,7 +1693,7 @@ test_that("--assocTest works", {
         "--test=firth",
         sprintf("--aggdb=%s", aggdb),
         sprintf("--geneSet=%s", genesetfile),
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--output=assocTest.txt.gz"
       )
     },
@@ -1742,7 +1745,7 @@ test_that("--assocTest works", {
         "--pheno=pheno",
         "--test=firth,glm",
         sprintf("--geneSet=%s", genesetfile),
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--cohort=pheno",
         "--name=test",
         "--continuous",
@@ -1993,7 +1996,7 @@ test_that("--buildCorMatrix works", {
 
   # test defaults
   aggdb <- withr::local_tempfile()
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- gdb
   varsetfile <- varSetFile(rvat_example("rvatData_varsetfile.txt.gz"))
   varsetlist <- getVarSet(
     varsetfile,
@@ -2199,7 +2202,7 @@ test_that("--geneSetAssoc works", {
   ## cormatrix
   aggdb <- withr::local_tempfile()
   cormatrix <- withr::local_tempfile()
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- gdb
   varsetfile <- varSetFile(rvat_example("rvatData_varsetfile.txt.gz"))
   varsetlist <- getVarSet(
     varsetfile,
@@ -2410,7 +2413,7 @@ test_that("--writeVcf works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--writeVcf",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--output=writeVcf.txt.gz"
       )
     },
@@ -2426,7 +2429,7 @@ test_that("--writeVcf works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     output = "writeVcf.txt.gz"
   )
 
@@ -2452,7 +2455,7 @@ test_that("--writeVcf works", {
     commandArgs = function(trailingOnly = TRUE) {
       c(
         "--writeVcf",
-        sprintf("--gdb=%s", rvatData::rvat_example("rvatData.gdb")),
+        sprintf("--gdb=%s", gdb_path),
         "--output=writeVcf.txt.gz",
         sprintf("--VAR_id=%s", varids),
         sprintf("--IID=%s", iids),
@@ -2475,7 +2478,7 @@ test_that("--writeVcf works", {
 
   # check against expected args
   expected_args <- list(
-    object = gdb(rvatData::rvat_example("rvatData.gdb")),
+    object = gdb,
     output = "writeVcf.txt.gz",
     VAR_id = as.character(1:10),
     IID = as.character(1:10),

--- a/tests/testthat/test-gdb-extractRanges.R
+++ b/tests/testthat/test-gdb-extractRanges.R
@@ -20,7 +20,7 @@ create_test_ranges <- function() {
 }
 
 test_that("extractRanges basic functionality works", {
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- create_example_gdb()
   ranges <- create_test_ranges()
 
   # check basic extraction
@@ -48,7 +48,7 @@ test_that("extractRanges basic functionality works", {
 })
 
 test_that("extractRanges handles different input formats", {
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- create_example_gdb()
 
   # ensembl gene info
   gtf <- readr::read_tsv(
@@ -84,7 +84,7 @@ test_that("extractRanges handles different input formats", {
 })
 
 test_that("extractRanges padding functionality works", {
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- create_example_gdb()
 
   # check whether INDELs are extracted correctly
   # includes three deletions that should overlap the start coordinates of ranges
@@ -104,11 +104,11 @@ test_that("extractRanges padding functionality works", {
     ranges = ranges,
     padding = 10L
   )
-  expect_identical(check_with_padding, c("1362", "1206", "1765"))
+  expect_identical(sort(check_with_padding), sort(c("1362", "1206", "1765")))
 })
 
 test_that("extractRanges handles edge cases correctly", {
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- create_example_gdb()
   ranges <- create_test_ranges()
 
   # check no overlap message and empty result
@@ -148,7 +148,7 @@ test_that("extractRanges handles edge cases correctly", {
 })
 
 test_that("extractRanges input validation works correctly", {
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- create_example_gdb()
   ranges <- create_test_ranges()$basic
 
   # expect an error when invalid padding values are provided

--- a/tests/testthat/test-gdb-getGT.R
+++ b/tests/testthat/test-gdb-getGT.R
@@ -1,6 +1,6 @@
 test_that("getGT basic functionality works", {
   # GT with 100 variants for testing
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- create_example_gdb()
   GT <- expect_no_error(getGT(
     gdb,
     VAR_id = 1:100,
@@ -27,7 +27,7 @@ test_that("getGT basic functionality works", {
 
 
 test_that("getGT handles invalid VAR_ids correctly", {
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- create_example_gdb()
 
   # loading VAR_ids that are not present in gdb should yield a warning
   GT_reference <- getGT(gdb, VAR_id = 1:100, cohort = "pheno", verbose = FALSE)
@@ -58,7 +58,7 @@ test_that("getGT handles invalid VAR_ids correctly", {
 })
 
 test_that("getGT works with varSet and weights", {
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- create_example_gdb()
 
   # build a varset containing CADD weights
   CADD_file <- withr::local_tempfile(fileext = ".txt.gz")
@@ -105,7 +105,7 @@ test_that("getGT works with varSet and weights", {
 })
 
 test_that("getGT handles different cohort specifications", {
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- create_example_gdb()
 
   # test specifying gdb cohort name
   GT1 <- getGT(gdb, VAR_id = 1:100, cohort = "pheno", verbose = FALSE)
@@ -125,7 +125,7 @@ test_that("getGT handles different cohort specifications", {
 })
 
 test_that("getGT annotation functionality works", {
-  gdb <- gdb(rvatData::rvat_example("rvatData.gdb"))
+  gdb <- create_example_gdb()
 
   # GT without annotations
   GT1 <- getGT(gdb, VAR_id = 1:100, cohort = "pheno", verbose = FALSE)


### PR DESCRIPTION
- for now, stick to sqlite for aggdb
- read files directly in `getAnno` using `read_csv_auto`
- minor fixes in `concatGdb` to pass unit tests
- minor fixes in `spatialClust` and `buildVarSet` (explicitly order by VAR_id in group_concats)
- add back in creationDate insertion into metadata in `buildGdb`
- update units tests: **note**: added a `create_example_gdb()` function in setup.R that masks create_example_gdb from rvatData. It expects a duckdb version 'rvatData.gdb' in 'tests/testthat/data/'